### PR TITLE
allow exceptions from sequence steps to be re-raised

### DIFF
--- a/lib/rspec_sequencing.rb
+++ b/lib/rspec_sequencing.rb
@@ -1,1 +1,3 @@
+# encoding: utf-8
+
 require "rspec/sequencing"

--- a/rspec-sequencing.gemspec
+++ b/rspec-sequencing.gemspec
@@ -4,7 +4,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rspec-sequencing"
-  spec.version       = "0.1.0"
+  spec.version       = "0.1.1"
+  spec.licenses      = ['Apache-2.0']
   spec.authors       = ["Elastic"]
   spec.email         = ["info@elastic.co"]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
+# encoding: utf-8
+
 # uses ruby-concurrent, so we can use Concurrent.monotonic_time
-require "rspec_sequencing"
+require 'rspec_sequencing'
 
 module RSpec
   class TimedTuple


### PR DESCRIPTION
RSpec::Expectations::ExpectationNotMetError created by rspec-wait
are swallowed by Concurrent::Dataflow

These can be re-raised to fail the test when the wait
conditions are not met